### PR TITLE
removes 'your experiences' and 'profile' from both desktop and mobile…

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,8 +14,7 @@
 
     <!-- Links when logged in -->
     <%= link_to "Facilitate an Experience", new_nde_path, class: "navbar-wagon-item navbar-wagon-link" %>
-    <%= link_to "Your Experiences", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-    <%= link_to "Dashboard", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+    <%= link_to "Dashboard", user_path(current_user), class: "navbar-wagon-item navbar-wagon-link" %>
 
     <!-- Avatar with dropdown menu -->
     <div class="navbar-wagon-item">
@@ -27,16 +26,6 @@
         <% end %>
         <%= cl_image_tag photo, class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
         <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-          <li>
-            <%= link_to user_path(current_user) do %>
-            <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
-            <% end %>
-          </li>
-          <li>
-            <%= link_to "#" do %>
-            <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
-            <% end %>
-          </li>
           <li>
             <%= link_to destroy_user_session_path, method: :delete do %>
             <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Log out") %>
@@ -57,15 +46,9 @@
     <div class="dropdown">
       <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
       <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-        <li>
-          <%= link_to "Profile", user_path(current_user), class: "navbar-wagon-item navbar-wagon-link" %>
-        </li>
+        <li><%= link_to "Dashboard", user_path(current_user), class: "navbar-wagon-item navbar-wagon-link" %></li>
         <li><%= link_to "Facilitate an Experience", new_nde_path, class: "navbar-wagon-item navbar-wagon-link" %></li>
-        <li><%= link_to "Your Experiences", "#", class: "navbar-wagon-item navbar-wagon-link" %></li>
-        <li><%= link_to "Dashboard", "#", class: "navbar-wagon-item navbar-wagon-link" %></li>
         <li><%= link_to "Log Out", destroy_user_session_path, class: "navbar-wagon-item navbar-wagon-link", method: :delete %></li>
-
-
       </ul>
     </div>
   </div>


### PR DESCRIPTION
<img width="1367" alt="nav-bar-newlinks" src="https://user-images.githubusercontent.com/34426996/44258728-f1382d80-a20f-11e8-9b20-a2b2c97b1b9f.png">
… navbars. Dashboard path now leads to profile